### PR TITLE
Enhancement whole country analysis

### DIFF
--- a/tests/test_make_perf_series.R
+++ b/tests/test_make_perf_series.R
@@ -7,12 +7,12 @@ load('test-data/perf_data_colnames.rda')
 #p4h <- make_p4h_from_sitreps(AE_data_test)
 
 testthat::test_that("Created timeseries dataset is a dataframe",{
-  ps_rqm_all_all <- make_perf_series(df = AE_data_test, prov_codes = c('RQM'),
-                                          measure = 'All')
-  ps_rqm_all_typ1 <- make_perf_series(df = AE_data_test, prov_codes = c('RQM'),
-                                     measure = 'Typ1')
-  ps_rqm_adm_all <- make_perf_series(df = AE_data_test, prov_codes = c('RQM'),
-                                     measure = 'Adm')
+  ps_rqm_all_all <- make_perf_series(df = AE_data_test, code = 'RQM',
+                                          measure = 'All', level = "Provider")
+  ps_rqm_all_typ1 <- make_perf_series(df = AE_data_test, code = 'RQM',
+                                     measure = 'Typ1', level = "Provider")
+  ps_rqm_adm_all <- make_perf_series(df = AE_data_test, code = 'RQM',
+                                     measure = 'Adm', level = "Provider")
   
   testthat::expect_is(ps_rqm_all_all, 'data.frame')
   testthat::expect_is(ps_rqm_all_typ1, 'data.frame')
@@ -20,12 +20,12 @@ testthat::test_that("Created timeseries dataset is a dataframe",{
 })
 
 testthat::test_that("Results for selected months in performance series for Chelsea and Westminster are correct",{
-  ps_rqm_all_all <- make_perf_series(df = AE_data_test, prov_codes = c('RQM'),
-                                            measure = 'All')
-  ps_rqm_all_typ1 <- make_perf_series(df = AE_data_test, prov_codes = c('RQM'),
-                                             measure = 'Typ1')
-  ps_rqm_adm_all <- make_perf_series(df = AE_data_test, prov_codes = c('RQM'),
-                                            measure = 'Adm')
+  ps_rqm_all_all <- make_perf_series(df = AE_data_test, code = 'RQM',
+                                            measure = 'All', level = "Provider")
+  ps_rqm_all_typ1 <- make_perf_series(df = AE_data_test, code = 'RQM',
+                                             measure = 'Typ1', level = "Provider")
+  ps_rqm_adm_all <- make_perf_series(df = AE_data_test, code = 'RQM',
+                                            measure = 'Adm', level = "Provider")
   
   # Test that we get the correct results for Chelsea and Westminster (RQM)
   # in April 2017, for all attendances
@@ -72,12 +72,12 @@ testthat::test_that("Results for selected months in performance series for Chels
 })
 
 testthat::test_that("Results for selected months in performance series for Imperial are correct",{
-  ps_ryj_all_all <- make_perf_series(df = AE_data_test, prov_codes = c('RYJ'),
-                                     measure = 'All')
-  ps_ryj_all_typ1 <- make_perf_series(df = AE_data_test, prov_codes = c('RYJ'),
-                                      measure = 'Typ1')
-  ps_ryj_adm_all <- make_perf_series(df = AE_data_test, prov_codes = c('RYJ'),
-                                     measure = 'Adm')
+  ps_ryj_all_all <- make_perf_series(df = AE_data_test, code = 'RYJ',
+                                     measure = 'All', level = "Provider")
+  ps_ryj_all_typ1 <- make_perf_series(df = AE_data_test, code = 'RYJ',
+                                      measure = 'Typ1', level = "Provider")
+  ps_ryj_adm_all <- make_perf_series(df = AE_data_test, code = 'RYJ',
+                                     measure = 'Adm', level = "Provider")
   
   # Test that we get the correct results for Imperial (RYJ)
   # in September 2017, for all attendances

--- a/tests/test_perf_plot.R
+++ b/tests/test_perf_plot.R
@@ -5,10 +5,10 @@ source("../spc_rules.R")
 load('test-data/AE_data_test.rda')
 
 testthat::test_that("Performance plot is correct for April 2017 for Chelsea and Westminster",{
-  ppchart_all <- plot_performance(df = AE_data_test, prov_codes = c('RQM'), brk.date = NULL, measure = 'All',
-                                  start.date = "2014-01-01", end.date = "2017-06-30")
-  ppchart_typ1 <- plot_performance(df = AE_data_test, prov_codes = c('RQM'), brk.date = NULL, measure = 'Typ1',
-                                   start.date = "2014-01-01", end.date = "2017-06-30")
+  ppchart_all <- plot_performance(df = AE_data_test, code = 'RQM', brk.date = NULL, measure = 'All',
+                                  start.date = "2014-01-01", end.date = "2017-06-30", level = "Provider")
+  ppchart_typ1 <- plot_performance(df = AE_data_test, code = 'RQM', brk.date = NULL, measure = 'Typ1',
+                                   start.date = "2014-01-01", end.date = "2017-06-30", level = "Provider")
   
   # Check output is a ggplot
   testthat::expect_is(ppchart_all, "ggplot")
@@ -47,9 +47,9 @@ testthat::test_that("Performance plot is correct for April 2017 for Chelsea and 
 })
 
 testthat::test_that("Volume plot is correct for April 2017 for Chelsea and Westminster",{
-  vchart_all <- plot_volume(df = AE_data_test, prov_codes = c('RQM'), brk.date = NULL, measure = 'All',
+  vchart_all <- plot_volume(df = AE_data_test, code = 'RQM', brk.date = NULL, measure = 'All',
                             start.date = "2014-01-01", end.date = "2017-06-30")
-  vchart_typ1 <- plot_volume(df = AE_data_test, prov_codes = c('RQM'), brk.date = NULL, measure = 'Typ1',
+  vchart_typ1 <- plot_volume(df = AE_data_test, code = 'RQM', brk.date = NULL, measure = 'Typ1',
                              start.date = "2014-01-01", end.date = "2017-06-30")
   
   # Check output is a ggplot


### PR DESCRIPTION
The regional and national analyses are now done using radio buttons.  

The main way that this is achieved is by the creation of a new function, `clean_region_col`, which standardises the region names in the `AE_Data` data frame and also includes a column for country as well as regional and national codes.  This function is called immediately after the data is downloaded.

The `regional_analysis` function is then called in `make_perf_series` and summarises the data frame based on the selected level.  

In general I have made a lot of changes to make the code more consistent with these new analyses. For example I changed most of the provider specific variable names (e.g. `Prov_Code`) to more general names (e.g. `Code`).  
